### PR TITLE
Removed comment tags that cause validation errors

### DIFF
--- a/ESRI Shapefile stylesheets/GeoServer stylesheets (SLD)/Backdrop style/land_use_symbol.sld
+++ b/ESRI Shapefile stylesheets/GeoServer stylesheets (SLD)/Backdrop style/land_use_symbol.sld
@@ -2,7 +2,6 @@
 <StyledLayerDescriptor version='1.0.0' xmlns='http://www.opengis.net/sld' xmlns:ogc='http://www.opengis.net/ogc'
 xmlns:xlink='http://www.w3.org/1999/xlink' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
 xsi:schemaLocation='http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd'>
-<!--
   <NamedLayer>
     <Name>Strategi&#174;</Name>
     <UserStyle>
@@ -229,5 +228,4 @@ xsi:schemaLocation='http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       </FeatureTypeStyle>
     </UserStyle>
   </NamedLayer>
--->
 </StyledLayerDescriptor>

--- a/ESRI Shapefile stylesheets/GeoServer stylesheets (SLD)/Backdrop style/tourist_symbol.sld
+++ b/ESRI Shapefile stylesheets/GeoServer stylesheets (SLD)/Backdrop style/tourist_symbol.sld
@@ -2,7 +2,6 @@
 <StyledLayerDescriptor version='1.0.0' xmlns='http://www.opengis.net/sld' xmlns:ogc='http://www.opengis.net/ogc'
 xmlns:xlink='http://www.w3.org/1999/xlink' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
 xsi:schemaLocation='http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd'>
-<!-- 
   <NamedLayer>
     <Name>Strategi&#174;</Name>
     <UserStyle>
@@ -1140,5 +1139,4 @@ xsi:schemaLocation='http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
       </FeatureTypeStyle>          
     </UserStyle>
   </NamedLayer>
--->
 </StyledLayerDescriptor>


### PR DESCRIPTION
The land_use_symbol.sld and tourist_symbol.sld Backdrop styles contain nested comment tags that are causing validation errors.  This pull request removes the nested comment tags to match the Full Colour styles.